### PR TITLE
서버 MariaDB 연동, EnableJpaAuditing 어노테이션 추가, 테스트 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,16 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	//테스트 의존성
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework:spring-test:6.0.13'
+
+	//QueryDsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/knj/mirou/MirouApplication.java
+++ b/src/main/java/com/knj/mirou/MirouApplication.java
@@ -2,7 +2,9 @@ package com.knj.mirou;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class MirouApplication {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,15 @@
+server:
+  port: 8080
+
 spring:
+  profiles:
+    active: dev
+    include: secret
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
-    url: jdbc:mariadb://localhost:3308/mirou__dev?useUnicode=true&characterEncoding=utf8&autoReconnect=true&serverTimezone=Asia/Seoul
-    username: root
-    password:
+    url: # 서버 DB URL
+    username: # 서버 DB username
+    password: # 서버 DB password
   jpa:
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
- [x] 서버 MariaDB 연동
- [x] 기존 yml 내용 삭제 및 secret에 내용 추가 (ignore)
- [x] 애플리케이션에 EnableJpaAuditing 어노테이션 추가
- [x] 테스트를 위한 의존성 build.gradle에 추가